### PR TITLE
guard-duty: Set default values to 'N/A'

### DIFF
--- a/cf-stacks/guard-duty-member-invite.yaml
+++ b/cf-stacks/guard-duty-member-invite.yaml
@@ -111,26 +111,26 @@ Metadata:
          - EmailAddress20
 
 Conditions:
-  Member01: !Not [ !Equals [ !Ref MemberId01, "" ] ]
-  Member02: !Not [ !Equals [ !Ref MemberId02, "" ] ]
-  Member03: !Not [ !Equals [ !Ref MemberId03, "" ] ]
-  Member04: !Not [ !Equals [ !Ref MemberId04, "" ] ]
-  Member05: !Not [ !Equals [ !Ref MemberId05, "" ] ]
-  Member06: !Not [ !Equals [ !Ref MemberId06, "" ] ]
-  Member07: !Not [ !Equals [ !Ref MemberId07, "" ] ]
-  Member08: !Not [ !Equals [ !Ref MemberId08, "" ] ]
-  Member09: !Not [ !Equals [ !Ref MemberId09, "" ] ]
-  Member10: !Not [ !Equals [ !Ref MemberId10, "" ] ]
-  Member11: !Not [ !Equals [ !Ref MemberId11, "" ] ]
-  Member12: !Not [ !Equals [ !Ref MemberId12, "" ] ]
-  Member13: !Not [ !Equals [ !Ref MemberId13, "" ] ]
-  Member14: !Not [ !Equals [ !Ref MemberId14, "" ] ]
-  Member15: !Not [ !Equals [ !Ref MemberId15, "" ] ]
-  Member16: !Not [ !Equals [ !Ref MemberId16, "" ] ]
-  Member17: !Not [ !Equals [ !Ref MemberId17, "" ] ]
-  Member18: !Not [ !Equals [ !Ref MemberId18, "" ] ]
-  Member19: !Not [ !Equals [ !Ref MemberId19, "" ] ]
-  Member20: !Not [ !Equals [ !Ref MemberId20, "" ] ]
+  Member01: !Not [ !Equals [ !Ref MemberId01, "N/A" ] ]
+  Member02: !Not [ !Equals [ !Ref MemberId02, "N/A" ] ]
+  Member03: !Not [ !Equals [ !Ref MemberId03, "N/A" ] ]
+  Member04: !Not [ !Equals [ !Ref MemberId04, "N/A" ] ]
+  Member05: !Not [ !Equals [ !Ref MemberId05, "N/A" ] ]
+  Member06: !Not [ !Equals [ !Ref MemberId06, "N/A" ] ]
+  Member07: !Not [ !Equals [ !Ref MemberId07, "N/A" ] ]
+  Member08: !Not [ !Equals [ !Ref MemberId08, "N/A" ] ]
+  Member09: !Not [ !Equals [ !Ref MemberId09, "N/A" ] ]
+  Member10: !Not [ !Equals [ !Ref MemberId10, "N/A" ] ]
+  Member11: !Not [ !Equals [ !Ref MemberId11, "N/A" ] ]
+  Member12: !Not [ !Equals [ !Ref MemberId12, "N/A" ] ]
+  Member13: !Not [ !Equals [ !Ref MemberId13, "N/A" ] ]
+  Member14: !Not [ !Equals [ !Ref MemberId14, "N/A" ] ]
+  Member15: !Not [ !Equals [ !Ref MemberId15, "N/A" ] ]
+  Member16: !Not [ !Equals [ !Ref MemberId16, "N/A" ] ]
+  Member17: !Not [ !Equals [ !Ref MemberId17, "N/A" ] ]
+  Member18: !Not [ !Equals [ !Ref MemberId18, "N/A" ] ]
+  Member19: !Not [ !Equals [ !Ref MemberId19, "N/A" ] ]
+  Member20: !Not [ !Equals [ !Ref MemberId20, "N/A" ] ]
 
 Parameters:
   MasterGuardDuty:
@@ -140,142 +140,182 @@ Parameters:
   MemberId01:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress01:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId02:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress02:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId03:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress03:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId04:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress04:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId05:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress05:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId06:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress06:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId07:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress07:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId08:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress08:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId09:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress09:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId10:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress10:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId11:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress11:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId12:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress12:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId13:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress13:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId14:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress14:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId15:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress15:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId16:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress16:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId17:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress17:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId18:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress18:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId19:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress19:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId20:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress20:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
 Resources:
   AccountInvite01:

--- a/cf-stacks/guard-duty.yaml
+++ b/cf-stacks/guard-duty.yaml
@@ -126,142 +126,182 @@ Parameters:
   MemberId01:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress01:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId02:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress02:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId03:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress03:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId04:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress04:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId05:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress05:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId06:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress06:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId07:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress07:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId08:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress08:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId09:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress09:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId10:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress10:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId11:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress11:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId12:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress12:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId13:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress13:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId14:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress14:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId15:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress15:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId16:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress16:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId17:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress17:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId18:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress18:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId19:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress19:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
   MemberId20:
     Description: The AWS account number of the member account
     Type: String
+    Default: "N/A"
   EmailAddress20:
     Description: The email address associated with the member AWS account
     Type: String
+    Default: "N/A"
 
 Conditions:
   IsMasterAccount: !Equals [ !Ref "AWS::AccountId" , !Ref MasterId ]
@@ -420,13 +460,13 @@ Resources:
     Type: AWS::KMS::Alias
     Properties:
       # Alias names must start with "alias/" ...
-      AliasName: !Sub "alias/${AWS::AccountId}-guardduty"
+      AliasName: !Sub "alias/ised-kms-${AWS::AccountId}-guardduty"
       TargetKeyId: !Ref EncryptionKey
 
   S3Bucket:
     Type: AWS::CloudFormation::Stack
     Properties:
-      TemplateURL: https://ised-s3-256255698049-cf.s3.ca-central-1.amazonaws.com/cf-stacks/s3.yaml
+      TemplateURL: https://ised-s3-256255698049-cf.s3.ca-central-1.amazonaws.com/s3.yaml
       Parameters:
         Name: guardduty
         Access: GuardDuty


### PR DESCRIPTION
Skip resource creation if Member IDs are left as 'N/A'