### PR TITLE
update role req'd for openshift-installer

### DIFF
--- a/cf-stacks/roles.yaml
+++ b/cf-stacks/roles.yaml
@@ -411,6 +411,15 @@ Resources:
               - iam:RemoveRoleFromInstanceProfile
               - iam:SimulatePrincipalPolicy
               - iam:TagRole
+              - iam:CreateAccessKey
+              - iam:CreateUser
+              - iam:DeleteAccessKey
+              - iam:DeleteUser
+              - iam:DeleteUserPolicy
+              - iam:GetUserPolicy
+              - iam:ListAccessKeys
+              - iam:PutUserPolicy
+              - iam:TagUser
             Resource: '*'
       Users: 
         - !Ref OpenShiftInstallUser
@@ -469,6 +478,9 @@ Resources:
               - s3:PutBucketAcl
               - s3:PutBucketTagging
               - s3:PutEncryptionConfiguration
+              - s3:PutLifecycleConfiguration
+              - s3:HeadBucket
+              - s3:ListBucketMultipartUploads
             Resource: '*'
       Users: 
         - !Ref OpenShiftInstallUser


### PR DESCRIPTION
OCP4 installer also requires the following permissions:

action="iam:CreateAccessKey"
action="iam:CreateUser"
action="iam:DeleteAccessKey"
action="iam:DeleteUser"
action="iam:DeleteUserPolicy"
action="iam:GetUserPolicy"
action="iam:ListAccessKeys"
action="iam:PutUserPolicy"
action="iam:TagUser"
action="s3:PutLifecycleConfiguration"
action="s3:HeadBucket"
action="s3:ListBucketMultipartUploads"
action="s3:AbortMultipartUpload"
action="iam:GetUserPolicy"
action="iam:ListAccessKeys"
