### PR TITLE
another missing role

### DIFF
--- a/cf-stacks/roles.yaml
+++ b/cf-stacks/roles.yaml
@@ -420,6 +420,7 @@ Resources:
               - iam:ListAccessKeys
               - iam:PutUserPolicy
               - iam:TagUser
+              - iam:CreateServiceLinkedRole 
             Resource: '*'
       Users: 
         - !Ref OpenShiftInstallUser


### PR DESCRIPTION
OCP4 installer also requires the following permissions:

iam:CreateServiceLinkedRole
