### PR TITLE
rds: Change default backup/maintenance window for EDT

### DIFF
--- a/rds.yaml
+++ b/rds.yaml
@@ -75,7 +75,7 @@ Parameters:
     # This needs to be changed twice a year for EST/EDT (see: COPS-2174)
     Description: "The time at which backups will be done (select 05:00-06:00 when it's daylight saving, 06:00-07:00 when it's standard time)"
     Type: String
-    Default: "06:00-07:00"
+    Default: "05:00-06:00"
     AllowedValues:
       - "05:00-06:00"
       - "06:00-07:00"
@@ -84,7 +84,7 @@ Parameters:
     # This needs to be changed twice a year for EST/EDT (see: COPS-2174)
     Description: "The time at which maintenance will be done (select 07:30-08:00 when it's daylight saving, 08:30-09:00 when it's standard time)"
     Type: String
-    Default: "tue:08:30-tue:09:00"
+    Default: "tue:07:30-tue:08:00"
     AllowedValues:
       - "tue:07:30-tue:08:00"
       - "tue:08:30-tue:09:00"


### PR DESCRIPTION
Due to recent time-change