### PR TITLE
config-termination: Add DependsOn to Config rule

### DIFF
--- a/cf-stacks/config-rule-termination.yaml
+++ b/cf-stacks/config-rule-termination.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: "2010-09-09"
 # Version 1.0 - Initial version
-Description: TODO
+Description: Initial version. Version 1.0
 
 Parameters:
   AccountIDMaster:
@@ -26,6 +26,7 @@ Resources:
   # Config rule that checks whether your resources have Termination Protection enabled
   TerminationConfigRule:
     Type: AWS::Config::ConfigRule
+    DependsOn: PermitConfig
     Properties:
       ConfigRuleName: ised-config-termination-rule
       Description: Checks whether your resources have Termination Protection enabled.


### PR DESCRIPTION
Make sure the config rule is created after we give it permissions to
execute the lambda. AWS Config actually checks if it can run it, and
fails the stack if it can't.

Without this, sometimes stack creation succeeds and sometimes it fails,
depending on what gets created first.