### PR TITLE
atlassian: Don't specify root vol. size on restore

### DIFF
--- a/accounts/cots/bitbucket.yaml
+++ b/accounts/cots/bitbucket.yaml
@@ -94,7 +94,7 @@ Resources:
         EC2OS: Linux
         EC2Size: t3.large
         EC2Ami: !Ref EC2Ami
-        EC2RootVolumeSize: !Ref EC2RootVolumeSize
+        EC2RootVolumeSize: !If [ IsEC2Restore, "", !Ref EC2RootVolumeSize ]
         UserData: ""
         EBSVolume1Size: !If [ IsEC2Restore, "", !Ref EC2AppVolumeSize ]
         EBSVolume1Mount: !If [ IsEC2Restore, "",!Ref EC2AppVolumeMount ]

--- a/accounts/cots/confluence.yaml
+++ b/accounts/cots/confluence.yaml
@@ -94,7 +94,7 @@ Resources:
         EC2OS: Linux
         EC2Size: t3.large
         EC2Ami: !Ref EC2Ami
-        EC2RootVolumeSize: !Ref EC2RootVolumeSize
+        EC2RootVolumeSize: !If [ IsEC2Restore, "", !Ref EC2RootVolumeSize ]
         UserData: ""
         EBSVolume1Size: !If [ IsEC2Restore, "", !Ref EC2AppVolumeSize ]
         EBSVolume1Mount: !If [ IsEC2Restore, "",!Ref EC2AppVolumeMount ]

--- a/accounts/cots/crowd.yaml
+++ b/accounts/cots/crowd.yaml
@@ -94,7 +94,7 @@ Resources:
         EC2OS: Linux
         EC2Size: t3.large
         EC2Ami: !Ref EC2Ami
-        EC2RootVolumeSize: !Ref EC2RootVolumeSize
+        EC2RootVolumeSize: !If [ IsEC2Restore, "", !Ref EC2RootVolumeSize ]
         UserData: ""
         EBSVolume1Size: !If [ IsEC2Restore, "", !Ref EC2AppVolumeSize ]
         EBSVolume1Mount: !If [ IsEC2Restore, "",!Ref EC2AppVolumeMount ]

--- a/accounts/cots/jira.yaml
+++ b/accounts/cots/jira.yaml
@@ -94,7 +94,7 @@ Resources:
         EC2OS: Linux
         EC2Size: t3.large
         EC2Ami: !Ref EC2Ami
-        EC2RootVolumeSize: !Ref EC2RootVolumeSize
+        EC2RootVolumeSize: !If [ IsEC2Restore, "", !Ref EC2RootVolumeSize ]
         UserData: ""
         EBSVolume1Size: !If [ IsEC2Restore, "", !Ref EC2AppVolumeSize ]
         EBSVolume1Mount: !If [ IsEC2Restore, "",!Ref EC2AppVolumeMount ]


### PR DESCRIPTION
Otherwise it works when the root volume size is the same or bigger than
the one in the AMI, but fails when it's smaller.