### PR TITLE
ec2: Don't define Security Group "GroupName"

### DIFF
--- a/ec2.yaml
+++ b/ec2.yaml
@@ -184,7 +184,10 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: "EC2 Security Group"
-      GroupName: !Join ['-', ["secg-ec2", !Ref "AWS::AccountId", !Ref ISEDProjectId ] ]
+      # "GroupName"s need to be unique. Defining one as below means we can't
+      # have two EC2s for the same ISEDProjectId. Let AWS generate a GroupName
+      # instead. We can differentiate them via the "Name" tag below
+      # GroupName: !Join ['-', ["secg-ec2", !Ref "AWS::AccountId", !Ref ISEDProjectId ] ]
       VpcId: !Ref VPCId
       Tags:
       - Key: Name


### PR DESCRIPTION
"GroupName"s need to be unique. Because it's derived from the
ISEDProjectId, it means that we can't have two instances of, for
example, JIRA ("ccots-jira") in the same account.

Let AWS generate a GroupName. We can differentiate them via the "Name"
tag.