### PR TITLE
config: Remove DBSecurityGroup from "cost" rule

### DIFF
--- a/cf-stacks/config.yaml
+++ b/cf-stacks/config.yaml
@@ -173,7 +173,6 @@ Resources:
         - AWS::ElasticLoadBalancing::LoadBalancer
         - AWS::ElasticLoadBalancingV2::LoadBalancer
         - AWS::RDS::DBInstance
-        - AWS::RDS::DBSecurityGroup
         - AWS::RDS::DBSnapshot
         - AWS::RDS::DBSubnetGroup
         - AWS::RDS::EventSubscription


### PR DESCRIPTION
1. They don't cost anything
2. Only one is created ("default") at AWS Account creation time
3. They can't be created manually via the Web Console. They've been
   replaced with EC2/VPC Security Groups