### PR TITLE
ocp-add-ons: Disable console for install IAM user

### DIFF
--- a/ocp-add-ons.yaml
+++ b/ocp-add-ons.yaml
@@ -280,9 +280,6 @@ Resources:
     Type: AWS::IAM::User
     Properties:
       UserName: IsedOcpUserInstall
-      LoginProfile:
-        Password: "CanadaIsed123!"
-        PasswordResetRequired: true
   HostedZone:
     Type: AWS::Route53::HostedZone
     Properties: 


### PR DESCRIPTION
This user requires API access, but not console access