### PR TITLE
rds: SecurityGroupRDS - set DeletionPolicy: Retain

### DIFF
--- a/rds.yaml
+++ b/rds.yaml
@@ -211,6 +211,7 @@ Conditions:
   IsMaxStorage: !Not [ !Equals [ !Ref RDSMaxStorage, "" ]]
 Resources:
   SecurityGroupRDS:
+    DeletionPolicy: Retain
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: "RDS Secuirty Group"


### PR DESCRIPTION
We retain the RDS, so we need to retain its sg. Otherwise cfn deletion
fails.